### PR TITLE
Avoid using extends with depends_on in docker-compose

### DIFF
--- a/data-driven-development/docker-compose.yml
+++ b/data-driven-development/docker-compose.yml
@@ -16,6 +16,9 @@ services:
     extends:
       file: ../utils/components.yml
       service: carla-ros-bridge
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     volumes:
       - *sensors-mount
       - ./launch/demo.launch.py:/demo.launch.py
@@ -28,6 +31,9 @@ services:
     extends:
       file: ../utils/components.yml
       service: carla-client
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     volumes:
       - ./src/time_controller.py:/opt/carla/PythonAPI/time_controller.py
     command: bash -ic "python time_controller.py --host carla-simulator ${max_simulation_time} ${max_real_time}"
@@ -36,6 +42,9 @@ services:
     extends:
       file: ../utils/components.yml
       service: carla-client
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     volumes:
       - ./src/spawned_vehicle_check.py:/opt/carla/PythonAPI/spawned_vehicle_check.py
     command: sleep infinity

--- a/software-prototyping/docker-compose.yml
+++ b/software-prototyping/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     extends:
       file: ../utils/components.yml
       service: carla-ros-bridge
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     volumes:
       - *launch-mount
       - *sensors-mount
@@ -24,11 +27,17 @@ services:
     extends:
       file: ../utils/components.yml
       service: ros-monitoring
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     volumes:
       - *rviz-config-mount
     command: bash -ic 'rviz2 -d /config.rviz --ros-args -p use_sim_time:=true &> /dev/null'
 
   image-segmentation:
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     image: rwthika/carlos-image-segmentation
     command: ros2 launch image_segmentation image_segmentation_launch.py image_topic:=/carla/ego_vehicle/rgb_front/image
     

--- a/utils/components.yml
+++ b/utils/components.yml
@@ -15,42 +15,27 @@ services:
   carla-client:
     extends:
       service: gpu-x11-service
-    depends_on:
-      carla-simulator:
-        condition: service_healthy
     image: rwthika/carla-simulator:client
     command: sleep infinity
 
   carla-scenario-runner:
     extends:
       service: gpu-x11-service
-    depends_on:
-      carla-simulator:
-        condition: service_healthy
     image: rwthika/carla-scenario-runner
 
   carla-ros-bridge:
     extends:
       service: gpu-x11-service
-    depends_on:
-      carla-simulator:
-        condition: service_healthy
     image: rwthika/carla-ros-bridge
 
   ros-monitoring:
     extends:
       service: gpu-x11-service
-    depends_on:
-      carla-simulator:
-        condition: service_healthy
     image: rwthika/ros2-cuda:humble-desktop-full
 
   ros-monitoring-offscreen:
     extends:
       service: gpu-service
-    depends_on:
-      carla-simulator:
-        condition: service_healthy
     image: rwthika/ros2-cuda:humble-desktop-full
 
   gpu-service:

--- a/utils/tutorial/README.md
+++ b/utils/tutorial/README.md
@@ -34,6 +34,9 @@ services:
     extends:
       file: ../components.yml
       service: carla-client
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     command: sleep infinity
 
   # starts the carla-ros-bridge
@@ -41,6 +44,9 @@ services:
     extends:
       file: ../components.yml
       service: carla-ros-bridge
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     # ...and then execute them. Note the -ic flag for an interactive bash!
     # Without an interactive bash, many important env vars wouldn't be working or even set
     command: bash -ic 'ros2 launch carla_ros_bridge carla_ros_bridge_with_example_ego_vehicle.launch.py host:=carla-simulator'
@@ -51,6 +57,9 @@ services:
     extends:
       file: ../components.yml
       service: ros-monitoring
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     volumes:
       # you can mount custom rviz configs...
       - *rviz-config-mount

--- a/utils/tutorial/docker-compose.yml
+++ b/utils/tutorial/docker-compose.yml
@@ -15,6 +15,9 @@ services:
     extends:
       file: ../components.yml
       service: carla-client
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     command: sleep infinity
 
   # starts the carla-ros-bridge
@@ -22,6 +25,9 @@ services:
     extends:
       file: ../components.yml
       service: carla-ros-bridge
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     # ...and then execute them. Note the -ic flag for an interactive bash!
     # Without an interactive bash, many important env vars wouldn't be working or even set
     command: bash -ic 'ros2 launch carla_ros_bridge carla_ros_bridge_with_example_ego_vehicle.launch.py host:=carla-simulator'
@@ -32,6 +38,9 @@ services:
     extends:
       file: ../components.yml
       service: ros-monitoring
+    depends_on:
+      carla-simulator:
+        condition: service_healthy
     volumes:
       # you can mount custom rviz configs...
       - *rviz-config-mount


### PR DESCRIPTION
In general [Docker Compose](https://docs.docker.com/compose) provides an `extends` and `depends_on` feature which could be use in combination. However, some newer versions of [Docker Compose](https://docs.docker.com/compose/release-notes/) do not support to extend a service A with a service B which defines a depends_on.

In order to support many Docker Compose versions (not only a working version such as v2.21.0) this Pull Request shifts the `depends_on` feature from service B to the top-level service A.